### PR TITLE
Add attributes mito_name and macs_gsize to fasta asset

### DIFF
--- a/asset_classes/fasta_attributes_asset_class.yaml
+++ b/asset_classes/fasta_attributes_asset_class.yaml
@@ -3,12 +3,12 @@ version: 0.0.1
 description: Attributes to Sequences in the FASTA file. mito_name (Mitocondrial chromosome name) and macs_gsize (Genome size).
 seek_keys:
   mito_name:
-    value: "{name}"
+    value: "{params.name}"
     description: Mitocondrial chromosome name
     type: string
   macs_gsize:
-    value: "{size}"
-    description: Genome size
+    value: "{params.name}"
+    description: Genome efective size
     type: string
 parents: 
   - fasta

--- a/asset_classes/fasta_attributes_asset_class.yaml
+++ b/asset_classes/fasta_attributes_asset_class.yaml
@@ -1,6 +1,6 @@
 name: fasta_attributes
 version: 0.0.1
-description: Attributes to Sequences in the FASTA file. mito_name (Mitocondrial chromosome name) and macs_gsize (Genome size).
+description: Sequences in the FASTA format, indexed FASTA (produced with samtools index), chromosome sizes file and attributes to Sequences in the FASTA file; mito_name (Mitocondrial chromosome name) and macs_gsize (Genome efective size).
 seek_keys:
   fasta:
     value: "{genome}.fa"

--- a/asset_classes/fasta_attributes_asset_class.yaml
+++ b/asset_classes/fasta_attributes_asset_class.yaml
@@ -2,6 +2,22 @@ name: fasta_attributes
 version: 0.0.1
 description: Attributes to Sequences in the FASTA file. mito_name (Mitocondrial chromosome name) and macs_gsize (Genome size).
 seek_keys:
+  fasta:
+    value: "{genome}.fa"
+    description: FASTA file
+    type: file
+  fai:
+    value: "{genome}.fa.fai"
+    description: FASTA index file
+    type: file
+  chrom_sizes:
+    value: "{genome}.chrom.sizes"
+    description: Chromosome sizes file
+    type: file
+  dict:
+    value: "{genome}.dict"
+    description: FASTA Dictionary file
+    type: file
   mito_name:
     value: "{params.name}"
     description: Mitocondrial chromosome name

--- a/asset_classes/fasta_attributes_asset_class.yaml
+++ b/asset_classes/fasta_attributes_asset_class.yaml
@@ -1,0 +1,14 @@
+name: fasta_attributes
+version: 0.0.1
+description: Attributes to Sequences in the FASTA file. mito_name (Mitocondrial chromosome name) and macs_gsize (Genome size).
+seek_keys:
+  mito_name:
+    value: "{name}"
+    description: Mitocondrial chromosome name
+    type: string
+  macs_gsize:
+    value: "{size}"
+    description: Genome size
+    type: string
+parents: 
+  - fasta

--- a/recipes/fasta_attributes_asset_recipe.yaml
+++ b/recipes/fasta_attributes_asset_recipe.yaml
@@ -11,7 +11,6 @@ inputs:
       description: Mitocondrial chromosome name
     size:
       description: Genome size
-  params: {}
   assets: {}
 container: docker.io/databio/refgenie
 default_tag: ''

--- a/recipes/fasta_attributes_asset_recipe.yaml
+++ b/recipes/fasta_attributes_asset_recipe.yaml
@@ -14,8 +14,10 @@ inputs:
   params: {}
   assets: {}
 container: docker.io/databio/refgenie
+default_tag: ''
 command_template_list:
-  - cp {{files.fasta}} {{asset_outfolder}}/{{genome}}.fa.gz
+  - echo {{params.name}}
+  - echo {{params.size}}
 test:
   inputs:
     name: "MT"

--- a/recipes/fasta_attributes_asset_recipe.yaml
+++ b/recipes/fasta_attributes_asset_recipe.yaml
@@ -1,0 +1,27 @@
+name: fasta_attributes
+version: 0.0.1
+output_asset_class: fasta_attributes
+description:
+  Attributes to Sequences in the FASTA file. 
+  mito_name (Mitocondrial chromosome name) and macs_gsize (Genome size).
+inputs:
+  files: {}
+  params:
+    name:
+      description: Mitocondrial chromosome name
+    size:
+      description: Genome size
+  params: {}
+  assets: {}
+container: docker.io/databio/refgenie
+command_template_list:
+  - cp {{files.fasta}} {{asset_outfolder}}/{{genome}}.fa.gz
+test:
+  inputs:
+    name: "MT"
+    size: "2.7e9"
+  outputs:
+    mito_name:
+      value: "MT"
+    macs_gsize:
+      value: "2.7e9"

--- a/recipes/fasta_attributes_asset_recipe.yaml
+++ b/recipes/fasta_attributes_asset_recipe.yaml
@@ -11,12 +11,16 @@ inputs:
       description: Mitocondrial chromosome name
     size:
       description: Genome size
-  assets: {}
+  assets:
+    fasta:
+      asset_class: fasta
+      default: fasta
+      description: fasta asset for genome
 container: docker.io/databio/refgenie
 default_tag: ''
 command_template_list:
-  - echo {{params.name}}
-  - echo {{params.size}}
+  - export name={{params.name}}
+  - export size={{params.size}}
 test:
   inputs:
     name: "MT"

--- a/recipes/fasta_attributes_asset_recipe.yaml
+++ b/recipes/fasta_attributes_asset_recipe.yaml
@@ -10,7 +10,7 @@ inputs:
     name:
       description: Mitocondrial chromosome name
     size:
-      description: Genome size
+      description: Genome efective size
   assets:
     fasta:
       asset_class: fasta
@@ -19,8 +19,6 @@ inputs:
 container: docker.io/databio/refgenie
 default_tag: ''
 command_template_list:
-  - export name={{params.name}}
-  - export size={{params.size}}
 test:
   inputs:
     name: "MT"


### PR DESCRIPTION
Add a new asset class child from "fasta" asset class. Add attributes mito_name and macs_gsize. 